### PR TITLE
feat: Allow primitive projections with postponed eta (not sort poly)

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -39,7 +39,7 @@ let to_entry mind (mb:mutual_inductive_body) : Entries.mutual_inductive_entry =
       let get_id p =
         match p.mind_record with
         | NotRecord | FakeRecord -> assert false
-        | PrimRecord (x,_,_,_) -> x
+        | PrimRecord {id; _ } -> id
       in
       Some (Some (Array.map get_id mb.mind_packets))
   in
@@ -162,7 +162,7 @@ let eq_in_context (ctx1, t1) (ctx2, t2) =
 
 let check_same_record r1 r2 = match r1, r2 with
   | NotRecord, NotRecord | FakeRecord, FakeRecord -> true
-  | PrimRecord (_,_,r1,tys1), PrimRecord (_,_,r2,tys2) ->
+  | PrimRecord { relevances = r1; tys = tys1 ; _ }, PrimRecord { relevances = r2; tys = tys2 ; _ } ->
     (* The kernel doesn't care about the names, we just need to check
        that the saved types are correct. *)
     Array.equal Sorts.relevance_equal r1 r2 &&

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -438,9 +438,10 @@ let v_wfp =
 
 let v_squash_info = v_sum "squash_info" 1 [|[|v_set v_quality|]|]
 
+let v_has_eta = v_enum "has_eta" 2
 let v_record_info =
   v_sum "record_info" 2
-    [| [| v_tuple "record" [| v_id; v_array v_id; v_array v_relevance; v_array v_constr |] |] |]
+    [| [| v_id; v_array v_id; v_array v_relevance; v_array v_constr; v_has_eta |] |]
 
 let v_one_ind = v_tuple "one_inductive_body"
   [|v_id;

--- a/dev/ci/user-overlays/21438-TDiazT-primitive-postponed-eta.sh
+++ b/dev/ci/user-overlays/21438-TDiazT-primitive-postponed-eta.sh
@@ -1,0 +1,2 @@
+overlay metarocq https://github.com/TDiazT/metarocq primitive-postponed-eta 21438
+overlay lean_importer https://github.com/TDiazT/rocq-lean-import primitive-postponed-eta 21438

--- a/doc/changelog/01-kernel/21438-primitive-postponed-eta-Changed.rst
+++ b/doc/changelog/01-kernel/21438-primitive-postponed-eta-Changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  Records in `Type` and `Prop`, with only fields in `SProp`,
+  can now have primitive projections but without eta conversion.
+  (`#21438 <https://github.com/rocq-prover/rocq/pull/21438>`_,
+  by Tomas Diaz).

--- a/doc/sphinx/addendum/sprop.rst
+++ b/doc/sphinx/addendum/sprop.rst
@@ -122,21 +122,28 @@ propositions, for instance:
    Set Primitive Projections.
    Record sProd (A B : SProp) : SProp := { sfst : A; ssnd : B }.
 
-On the other hand, to avoid having definitionally irrelevant types in
-non-:math:`\SProp` sorts (through record η-extensionality), primitive
-records in relevant sorts must have at least one relevant field.
+Primitive records in relevant sorts with fields that are only strict propositions
+are allowed but do not have η-conversion.
+This is in order to avoid having definitionally irrelevant types in
+non-:math:`\SProp` sorts (through record η-extensionality).
 
 .. rocqtop:: all
 
-   Set Warnings "+non-primitive-record".
-   Fail Record rBox (A:SProp) : Prop := rbox { runbox : A }.
+   Record rBox (A : SProp) : Prop := rbox { runbox : A }.
+
+   Goal forall (A : SProp) (r : rBox A), r = {| runbox := r.(runbox A) |}.
+   Proof. intros A r. Fail reflexivity. Abort.
+
+In contrast, primitive records in relevant sorts with at least one relevant field
+are allowed and have η-conversion.
 
 .. rocqdoc::
 
-   Record ssig (A:Type) (P:A -> SProp) : Type := { spr1 : A; spr2 : P spr1 }.
+   Record ssig (A : Type) (P : A -> SProp) : Type := { spr1 : A; spr2 : P spr1 }.
 
-Note that ``rBox`` works as an emulated record, which is equivalent to
-the Box inductive.
+   Goal forall (A : Type) (P : A -> SProp) (s : ssig A P),
+                s = {| spr1 := s.(spr1 A P); spr2 := s.(spr2 A P) |}.
+   Proof. intros A P s. reflexivity. Qed.
 
 Encodings for strict propositions
 ---------------------------------

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -950,7 +950,12 @@ let eta_expand_ind_stack env (ind,u) m (f, s') =
   (* disallow eta-exp for non-primitive records *)
   if not (mib.mind_finite == BiFinite) then raise Not_found;
   match Declareops.inductive_make_projections ind mib with
-  | Some projs ->
+  | Some (projs, has_eta) ->
+    let () =
+      match has_eta with
+      | NoEta -> raise Not_found
+      | AlwaysEta -> ()
+    in
     (* (Construct, pars1 .. parsm :: arg1...argn :: []) ~= (f, s') ->
            arg1..argn ~= (proj1 t...projn t) where t = zip (f,s') *)
     let pars = mib.Declarations.mind_nparams in

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -151,16 +151,24 @@ v}
     - The identifier for the binder name of the record in primitive projections.
     - The constants associated to each projection.
     - The projection types (under parameters).
+    - The recheck at eta conversion flag
 
     The kernel does not exploit the difference between [NotRecord] and
     [FakeRecord]. It is mostly used by extraction, and should be extruded from
     the kernel at some point.
 *)
+type has_eta = AlwaysEta | NoEta
 
 type record_info =
 | NotRecord
 | FakeRecord
-| PrimRecord of (Id.t * Id.t array * Sorts.relevance array * types array)
+| PrimRecord of {
+    id : Id.t;
+    projections : Id.t array;
+    relevances : Sorts.relevance array;
+    tys : types array;
+    has_eta : has_eta;
+  }
 
 type squash_info =
   | AlwaysSquashed

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -72,7 +72,7 @@ val inductive_make_projection : Names.inductive -> mutual_inductive_body -> proj
   Names.Projection.Repr.t * Sorts.relevance
 
 val inductive_make_projections : Names.inductive -> mutual_inductive_body ->
-  (Names.Projection.Repr.t * Sorts.relevance) array option
+  ((Names.Projection.Repr.t * Sorts.relevance) array * has_eta) option
 
 (** {6 Kernel flags} *)
 

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -125,13 +125,10 @@ let cook_one_ind info cache ~params ~ntypes mip =
   let mind_record = match mip.mind_record with
     | NotRecord -> NotRecord
     | FakeRecord -> FakeRecord
-    | PrimRecord (id,projs,relevances,tys) ->
-      let data =
+    | PrimRecord ({ relevances; tys; _ } as pinfo) ->
         let tys = Array.map (cook_projection cache ~params) tys in
         let relevances = Array.map (lift_relevance info) relevances in
-        (id,projs,relevances,tys)
-      in
-      PrimRecord data
+        PrimRecord { pinfo with relevances ; tys }
   in
 
   { mind_typename = mip.mind_typename;

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -737,10 +737,9 @@ let lookup_projection p env =
    then anomaly ~label:"lookup_projection" Pp.(str "Bad number of parameters on projection."));
   match mib.mind_packets.(i).mind_record with
   | NotRecord | FakeRecord -> anomaly ~label:"lookup_projection" Pp.(str "not a projection")
-  | PrimRecord infos ->
-    let _,_,rs,typs = infos in
+  | PrimRecord { relevances; tys; _ } ->
     let arg = Projection.arg p in
-    rs.(arg), typs.(arg)
+    relevances.(arg), tys.(arg)
 
 let get_projection env ind ~proj_arg =
   let mib = lookup_mind (fst ind) env in
@@ -748,7 +747,7 @@ let get_projection env ind ~proj_arg =
 
 let get_projections env ind =
   let mib = lookup_mind (fst ind) env in
-  Declareops.inductive_make_projections ind mib
+  Option.map fst @@ Declareops.inductive_make_projections ind mib
 
 (* Mutual Inductives *)
 let polymorphic_ind (mind,_i) env =

--- a/kernel/indTyping.mli
+++ b/kernel/indTyping.mli
@@ -32,7 +32,7 @@ type inductive_arity = { user_arity : Constr.types; sort : Sorts.t }
     - checked variance info
       (variance for section universes is at the beginning of the array)
     - record entry (checked to be OK)
-    - if primitive record was requested and not ok, the reason why it's not ok
+    - if primitive record was requested, either: (1) if it's not ok, then why, or (2) whether it has eta
     - parameters
     - for each inductive,
       (arity * constructors) (with params)
@@ -46,7 +46,7 @@ val typecheck_inductive : env -> sec_univs:UVars.Instance.t option
   * template_universes option
   * UVars.Variance.t array option
   * Names.Id.t array option option
-  * NotPrimRecordReason.t option
+  * (Declarations.has_eta, NotPrimRecordReason.t) result option
   * Constr.rel_context
   * ((inductive_arity * Constr.types array) *
      (Constr.rel_context * (Constr.rel_context * Constr.types) array) *

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -2262,9 +2262,8 @@ let compile_mind cenv mb mind stack =
     in
     let projs = match ob.mind_record with
     | NotRecord | FakeRecord -> []
-    | PrimRecord info ->
-      let _, _, _, pbs = info in
-      Array.fold_left_i add_proj [] pbs
+    | PrimRecord { tys ; _ } ->
+      Array.fold_left_i add_proj [] tys
     in
     projs @ gtype :: accu :: stack
   in

--- a/kernel/relevanceops.ml
+++ b/kernel/relevanceops.ml
@@ -37,9 +37,8 @@ let relevance_of_projection_repr env (p, u) =
   match mib.mind_packets.(i).mind_record with
   | NotRecord | FakeRecord ->
     CErrors.anomaly ~label:"relevance_of_projection" Pp.(str "not a projection")
-  | PrimRecord infos ->
-    let _,_,rs,_ = infos in
-    UVars.subst_instance_relevance u rs.(Names.Projection.Repr.arg p)
+  | PrimRecord { relevances; _ }->
+    UVars.subst_instance_relevance u relevances.(Names.Projection.Repr.arg p)
 
 let relevance_of_projection env (p,u) =
   relevance_of_projection_repr env (Names.Projection.repr p,u)

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -253,9 +253,8 @@ let relevance_of_projection_repr mip p =
   match mip.mind_record with
   | NotRecord | FakeRecord ->
     CErrors.anomaly ~label:"relevance_of_projection" Pp.(str "not a projection")
-  | PrimRecord infos ->
-    let _,_,rs,_ = infos in
-    rs.(Names.Projection.Repr.arg p)
+  | PrimRecord { relevances; _ } ->
+    relevances.(Names.Projection.Repr.arg p)
 
 (** Because of automatic unboxing the easy way [mk_def c] on the
    constant body of primitive projections doesn't work. We pretend
@@ -287,9 +286,8 @@ let fake_match_projection env p =
   let relevance = relevance_of_projection_repr mip p in
   let x = match mip.mind_record with
     | NotRecord | FakeRecord -> assert false
-    | PrimRecord info ->
-      let x, _, _, _ = info in
-      make_annot (Name x) mip.mind_relevance
+    | PrimRecord { id; _ } ->
+      make_annot (Name id) mip.mind_relevance
   in
   let indty = mkApp (indu, Context.Rel.instance mkRel 0 paramslet) in
   let rec fold arg j subst = function

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1335,6 +1335,7 @@ let () =
   define "ind_get_projections" (ind_data @-> ret (option (array projection)))
   @@ fun (ind,mib) ->
   Declareops.inductive_make_projections ind mib
+  |> Option.map fst
   |> Option.map (Array.map (fun (p,_) -> Projection.make p false))
 
 (** Proj *)

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -592,8 +592,7 @@ let compute_projections env (kn, i as ind) =
   let x = match mib.mind_packets.(i).mind_record with
   | NotRecord | FakeRecord ->
     anomaly Pp.(str "Trying to build primitive projections for a non-primitive record")
-  | PrimRecord info ->
-    let id, _, _, _ = info in
+  | PrimRecord { id ; _ } ->
     make_annot (Name id) (ERelevance.make mib.mind_packets.(i).mind_relevance)
   in
   let pkt = mib.mind_packets.(i) in

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1026,9 +1026,8 @@ let is_eta_constructor_app env sigma ts f l1 term =
     let open Declarations in
     let mib = lookup_mind mind env in
       (match mib.mind_packets.(i).mind_record with
-      | PrimRecord info when mib.Declarations.mind_finite == Declarations.BiFinite &&
-          let (_, projs, _, _) = info in
-          Array.length projs == Array.length l1 - mib.Declarations.mind_nparams ->
+      | PrimRecord { projections ; _ } when mib.Declarations.mind_finite == Declarations.BiFinite &&
+          Array.length projections == Array.length l1 - mib.Declarations.mind_nparams ->
         (* Check that the other term is neutral *)
         is_neutral env sigma ts term
       | _ -> false)

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -318,8 +318,7 @@ and nf_stk ?from:(from=0) env sigma c t stk  =
     let pars = List.firstn mib.mind_nparams args in
     let ty = match mip.mind_record with
     | NotRecord | FakeRecord -> assert false
-    | PrimRecord infos ->
-      let _, _, _, tys = infos in
+    | PrimRecord { tys; _ } ->
       let ty = Vars.subst_instance_constr (EConstr.Unsafe.to_instance u) tys.(p) in
       substl (c :: List.rev_map EConstr.Unsafe.to_constr pars) ty
     in

--- a/test-suite/output/Record.out
+++ b/test-suite/output/Record.out
@@ -90,12 +90,15 @@ File "./output/Record.v", line 95, characters 2-31:
 Warning:
 The record noprojs could not be defined as a primitive record because it has
 no projections. [non-primitive-record,records,default]
-File "./output/Record.v", line 97, characters 2-48:
-Warning:
-The record norelevantprojs could not be defined as a primitive record because
-it is not in SProp but all projections may be irrelevant.
-[non-primitive-record,records,default]
-File "./output/Record.v", line 99, characters 2-33:
+norelevantprojs : SProp -> Prop
+
+norelevantprojs is not universe polymorphic
+norelevantprojs is in Prop but its eliminators are declared dependent by default
+norelevantprojs has primitive projections without eta conversion.
+Arguments norelevantprojs A%_type_scope
+Expands to: Inductive Record.WhyNotPrim.norelevantprojs
+Declared in library Record, line 97, characters 9-24
+File "./output/Record.v", line 101, characters 2-33:
 Warning:
 The record anonproj could not be defined as a primitive record because it has
 an anonymous projection. [non-primitive-record,records,default]

--- a/test-suite/output/Record.v
+++ b/test-suite/output/Record.v
@@ -96,6 +96,8 @@ Module WhyNotPrim.
 
   Record norelevantprojs (A:SProp) := { z : A }.
 
+  About norelevantprojs.
+
   Record anonproj := { _ : nat }.
 
 End WhyNotPrim.

--- a/test-suite/success/record_postponed_eta.v
+++ b/test-suite/success/record_postponed_eta.v
@@ -1,0 +1,121 @@
+Set Primitive Projections.
+
+Record RTypeToSProp (A : SProp) : Type := {
+  f1 : A
+}.
+
+(* Conversion when record is in Type and field in SProp fails correctly *)
+Goal forall (A:SProp) (r2 : RTypeToSProp A), eq r2 {| f1 := r2.(f1 A) |}.
+Proof. intros A r2. Fail reflexivity. Abort.
+(* The command has indeed failed with message:
+    In environment
+    A : SProp
+    r2 : RTypeToSProp A
+    Unable to unify "{| f1 := f1 _ r2 |}" with "r2" *)
+
+Record RPropToSProp (A : SProp) : Prop := {
+  f2 : A
+}.
+
+(* Conversion when record is in Prop and field in SProp fails correctly *)
+Goal forall (A:SProp) (r2 : RPropToSProp A), eq r2 {| f2 := r2.(f2 A) |}.
+Proof. intros A r2. Fail reflexivity. Abort.
+(* The command has indeed failed with message:
+    In environment
+    A : SProp
+    r2 : RPropToSProp A
+    Unable to unify "{| f2 := f2 _ r2 |}" with "r2". *)
+
+Set Universe Polymorphism.
+
+Record RSToSProp@{s;u|s -> SProp} (A : SProp) : Type@{s;u} := {
+  f3 : A
+}.
+
+Inductive eq@{s s'; u} (A : Type@{s;u}) (a : A) : A -> Prop :=
+  eq_refl : eq A a a.
+
+Arguments eq {_}.
+Arguments eq_refl {_ _}.
+
+(* Conversion when record is in Type and field in SProp fails correctly *)
+Goal forall (A:SProp) (r2 : RSToSProp@{Type;0} A), eq r2 {| f3 := r2.(f3 A) |}.
+Proof. intros A r2. Fail reflexivity. Abort.
+(* The command has indeed failed with message:
+    In environment
+    A : SProp
+    r2 : RSToProp A
+    Unable to unify "{| f3 := f3 _ r2 |}" with "r2". *)
+
+Set Debug "cClosure".
+(* Conversion when record and field are instantiated to SProp checks correctly *)
+Goal forall (A:SProp) (r2 : RSToSProp@{SProp;0} A), eq r2 {| f3 := r2.(f3 A) |}.
+Proof. intros A r2. reflexivity. Qed.
+
+Record RSToS'@{s1 s2;u1 u2| s2 -> s1 +} (A : Type@{s1;u1}): Type@{s2;u2} := {
+  f4 : A
+}.
+
+(* Conversion when record is in Type and field in SProp fails correctly *)
+Goal forall (A:SProp) (r2 : RSToS'@{SProp Type;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
+Proof. intros A r2. Fail reflexivity. Abort.
+(* The command has indeed failed with message:
+  In environment
+  A : SProp
+  r2 : RSToS' A
+  Unable to unify "{| f4 := f4 _ r2 |}" with "r2". *)
+
+(* Conversion when record is in Prop and field in SProp fails correctly *)
+Goal forall (A:SProp) (r2 : RSToS'@{SProp Prop;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
+Proof. intros A r2. Fail reflexivity. Abort.
+(* The command has indeed failed with message:
+  In environment
+  A : SProp
+  r2 : RSToS' A
+  Unable to unify "{| f4 := f4 _ r2 |}" with "r2". *)
+
+(* Conversion when record and field are instantiated to SProp checks correctly *)
+Goal forall (A:SProp) (r2 : RSToS'@{SProp SProp;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
+Proof. intros A r2. reflexivity. Qed.
+
+(* Conversion when record and field are instantiated to the same sort (Type) still fails correctly because we haven't implemented it *)
+Goal forall (A:Set) (r2 : RSToS'@{Type Type;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
+Proof. intros A r2. Fail reflexivity. Abort.
+
+(* Conversion when record and field are instantiated to the same sort (Prop) still fails correctly because we haven't implemented it *)
+Goal forall (A:Prop) (r2 : RSToS'@{Prop Prop;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
+Proof. intros A r2. Fail reflexivity. Abort.
+
+(* Conversion when record is in Type and field is in Prop still fails correctly because we haven't implemented it *)
+Goal forall (A:Prop) (r2 : RSToS'@{Prop Type;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
+Proof. intros A r2. Fail reflexivity. Abort.
+
+Section Sorts.
+  Sort s s'.
+
+  Constraint s -> SProp.
+
+  (* Conversion when record is in Type and field in SProp fails correctly *)
+  Goal forall (A:SProp) (r2 : RSToSProp@{s;0} A), eq r2 {| f3 := r2.(f3 A) |}.
+  Proof. intros A r2. Fail reflexivity. Abort.
+  (* The command has indeed failed with message:
+    In environment
+    A : SProp
+    r2 : RSToProp A
+    Unable to unify "{| f3 := f3 _ r2 |}" with "r2". *)
+
+  Constraint s' -> s.
+
+  (* Conversion when record and field are instantiated to the different sorts fails correctly *)
+  Goal forall (A:Type@{s;0}) (r2 : RSToS'@{s s';0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
+  Proof. intros A r2. Fail reflexivity. Abort.
+  (* The command has indeed failed with message:
+    In environment
+    A : Type@{s ; _}
+    r2 : RSToS' A
+    Unable to unify "{| f4 := f4 _ r2 |}" with "r2". *)
+
+  (* Conversion when record and field are instantiated to the same sort (Type) still fails correctly because we haven't implemented it *)
+  Goal forall (A:Type@{s;0}) (r2 : RSToS'@{s s;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
+  Proof. intros A r2. Fail reflexivity. Abort.
+End Sorts.

--- a/test-suite/success/sprop.v
+++ b/test-suite/success/sprop.v
@@ -41,14 +41,11 @@ Proof.
   reflexivity.
 Defined.
 
-(* Primitive record with all fields in SProp has the eta property of SProp so must be SProp. *)
-Fail Record rBox (A:SProp) : Prop := rmkbox { runbox : A }.
-Section Opt.
-  Local Unset Primitive Projections.
-  Record rBox (A:SProp) : Prop := rmkbox { runbox : A }.
-End Opt.
+(* Primitive record in Prop with all fields in SProp does not have the eta property of SProp
+  but can be defined regardless. *)
+Record rBox (A:SProp) : Prop := rmkbox { runbox : A }.
 
-(* Check that defining as an emulated record worked *)
+(* Check that defining record without eta *)
 Check runbox.
 
 (* Check that it doesn't have eta *)

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -317,10 +317,12 @@ let print_type_in_type env ref =
 let print_primitive_record recflag mipv =
   let mipv = Array.to_list mipv in
   mipv |> List.concat_map @@ fun mip -> match mip.mind_record with
-  | PrimRecord _ ->
+  | PrimRecord { has_eta; _ } ->
     let eta = match recflag with
-      | CoFinite | Finite -> str" without eta conversion"
-      | BiFinite -> str " with eta conversion"
+      | CoFinite | Finite -> str " without eta conversion"
+      | BiFinite -> match has_eta with
+                    | NoEta -> str " without eta conversion"
+                    | AlwaysEta -> str " with eta conversion"
     in
     [Id.print mip.mind_typename ++ str" has primitive projections" ++ eta ++ str"."]
   | FakeRecord | NotRecord -> []

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -128,7 +128,7 @@ let print_one_inductive env sigma mib ((_,i) as ind) =
   let isrecord = match mip.mind_record with
     | NotRecord -> None
     | FakeRecord -> Some Anonymous
-    | PrimRecord (id,_,_,_) -> Some (Name id)
+    | PrimRecord { id; _ } -> Some (Name id)
   in
   if Option.has_some isrecord then assert (Array.length cstrtypes = 1);
   let inst =


### PR DESCRIPTION
This PR relaxes the constraints on defining records with primitive projections, namely for `Type` and `Prop`, by postponing the check to conversion. Namely, it introduces a new argument `has_eta` to decide whether to check or reject during conversion. 
- Records defined in `Type`/`Prop` with fields only in `SProp` can be defined and have `NoEta`, thus fail conversion.
- Records defined at some sort `s` with fields only in `SProp` can be defined and have `MaybeEta`, but currently fail during conversion.
- Records defined at some sort `s` with fields in other sorts are allowed and have `MaybeEta`.

### Examples
Test cases added in **success/record_postponed_eta.v**

```coq
Set Primitive Projections.

Record RTypeToSProp (A : SProp) : Type := { f1 : A }.

(* Conversion when record is in Type and field in SProp fails correctly *)
Goal forall (A:SProp) (r2 : RTypeToSProp A), eq r2 {| f1 := r2.(f1 A) |}.
Proof. intros A r2. Fail reflexivity. Abort.
(* Unable to unify "{| f1 := f1 _ r2 |}" with "r2" *)
    
Record RPropToSProp (A : SProp) : Prop := {  f2 : A }.

(* Conversion when record is in Prop and field in SProp fails correctly *)
Goal forall (A:SProp) (r2 : RPropToSProp A), eq r2 {| f2 := r2.(f2 A) |}.
Proof. intros A r2. Fail reflexivity. Abort.
(* Unable to unify "{| f2 := f2 _ r2 |}" with "r2". *)

Set Universe Polymorphism.

Record RSToSProp@{s;u|s -> SProp} (A : SProp) : Type@{s;u} := {  f3 : A }.

Inductive eq@{s s'; u} (A : Type@{s;u}) (a : A) : A -> Prop :=  eq_refl : eq A a a.

(* Conversion when record is in Type and field in SProp fails correctly *)
Goal forall (A:SProp) (r2 : RSToSProp@{Type;0} A), eq r2 {| f3 := r2.(f3 A) |}.
Proof. intros A r2. Fail reflexivity. Abort.
(* Unable to unify "{| f3 := f3 _ r2 |}" with "r2". *)
```

### Main API Changes
- `declarations.mli` : `PrimRecord` is now defined with a record, including a new argument of type `has_eta`.

----
<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

- [ ] Opened **overlay** pull requests.
